### PR TITLE
[Add] Support MesaTEE, prepare for leveldb

### DIFF
--- a/protected_fs_c/CMakeLists.txt
+++ b/protected_fs_c/CMakeLists.txt
@@ -17,6 +17,8 @@ include_directories("inc")
 option (NON_SGX_PROTECTED_FS
         "Use PROTECTED_FS NON SGX VERSION" ON)
 
+set (SGX_SDK $ENV{SGX_SDK})
+
 if (NON_SGX_PROTECTED_FS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -U__STRICT_ANSI__ -std=c++11 -lpthread -fPIC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs -Wno-shadow -Wno-missing-field-initializers -Wno-unused-parameter")
@@ -24,21 +26,9 @@ elseif (NOT EXISTS ${SGX_SDK})
     message(FATAL_ERROR "$SGX_SDK directory must exist")
 else ()
     message("SGX_SDK=${SGX_SDK}")
-
     set(SGX_LIBRARY_PATH  ${SGX_SDK}/lib64)
-    set(SGX_COMMON_CFLAGS  -m64 -O2)
-    set(SGX_UNTRUSTED_CFLAGS  ${SGX_COMMON_CFLAGS} -fPIC -Wno-attributes
-        -I${SGX_SDK}/include)
-    set(SGX_TRUSTED_CFLAGS  ${SGX_COMMON_CFLAGS} -nostdinc -fvisibility=hidden
-        -fpie -fstack-protector
-        -I${SGX_SDK}/include -I${SGX_SDK}/include/tlibc
-        -I${SGX_SDK}/include/stdc++ -I${SGX_SDK}/include/libcxx 
-        -I${SGX_SDK}/include/stlport -I${SGX_SDK}/include/epid)
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U__STRICT_ANSI__ -Werror")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs -Wno-shadow -Wno-missing-field-initializers -Wno-unused-parameter")
-    set(${PROJECT_NAME}_sgx_tprotected_fs_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SGX_TRUSTED_CFLAGS}")
-    set(${PROJECT_NAME}_sgx_uprotected_fs_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SGX_UNTRUSTED_CFLAGS}")
+    set(SGX_COMMON_CFLAGS  "-m64 -O2")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U__STRICT_ANSI__ -Werror -Wno-unused-local-typedefs -Wno-shadow -Wno-missing-field-initializers -Wno-unused-parameter")
 endif (NON_SGX_PROTECTED_FS)
 
 add_subdirectory (sgx_tprotected_fs)

--- a/protected_fs_c/build.sh
+++ b/protected_fs_c/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e 
+
+display_usage() { 
+	printf "Usage:\n  %s --build <dir> --mode {sgx|non_sgx} \n"  "$(basename "$0")"
+} 
+
+OPTS=`getopt -o b:m: --long build:,mode: -n 'parse-options' -- "$@"`
+
+if [ $? != 0 ]
+then 
+    display_usage
+    exit 1
+fi
+
+while true; do
+  case "$1" in
+    -b | --build ) BUILD_DIR="$2"; shift; shift ;;
+    -m | --mode) 
+        case "$2" in 
+            sgx) MODE="-DNON_SGX_PROTECTED_FS=OFF";;
+            non_sgx) MODE="-DNON_SGX_PROTECTED_FS=ON";;
+            *) echo "Invalid mode provided!";;
+        esac
+        shift; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ -z "$BUILD_DIR" ] || [ -z "$MODE" ]
+then 
+    display_usage
+    exit 1
+fi
+
+SOURCE_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+cmake "${MODE}" "${SOURCE_DIR}"
+cmake --build .
+
+# Final libraries will be installed to $BUILD_DIR/target

--- a/protected_fs_c/inc/sgx_error.h
+++ b/protected_fs_c/inc/sgx_error.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef _SGX_ERROR_H_
 #define _SGX_ERROR_H_

--- a/protected_fs_c/protected_fs_config.h.in
+++ b/protected_fs_c/protected_fs_config.h.in
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 #define PROTECTED_FS_VERSION_MAJOR @PROTECTED_FS_VERSION_MAJOR@
 #define PROTECTED_FS_VERSION_MINOR @PROTECTED_FS_VERSION_MINOR@
 #cmakedefine NON_SGX_PROTECTED_FS

--- a/protected_fs_c/sgx_tprotected_fs.h
+++ b/protected_fs_c/sgx_tprotected_fs.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 
 /**
@@ -259,14 +262,37 @@ int32_t SGXAPI sgx_fimport_auto_key(const char* filename, const sgx_key_128bit_t
 */
 int32_t SGXAPI sgx_fclear_cache(SGX_FILE* stream);
 
-/*
-*
-*
-*/
+
 #define SGX_AESGCM_MAC_SIZE             16
 typedef uint8_t aead_128bit_tag_t[SGX_AESGCM_MAC_SIZE];
 typedef aead_128bit_tag_t sgx_aes_gcm_128bit_tag_t;
+
+
+/* sgx_get_current_meta_gmac
+* Purpose: 
+*
+* Parameters:
+*     stream - [IN] the file handle
+*     out_gmac - [OUT] the current meta_data_gmac of the file
+*
+* Return value: 
+*     int32_t  - result, 0 - success, 1 - there was an error, check sgx_ferror for error code
+*/
 int32_t SGXAPI sgx_get_current_meta_gmac(SGX_FILE* stream, sgx_aes_gcm_128bit_tag_t out_gmac);
+
+
+/* sgx_rename_meta
+* Purpose: 
+*
+* Parameters:
+*     stream - [IN] the file handle
+*     old_name - [IN] the existing file name
+*     new_name - [IN] the new name
+*
+* Return value: 
+*     int32_t  - result, 0 - success, 1 - there was an error, check sgx_ferror for error code
+*/
+int32_t SGXAPI sgx_rename_meta(SGX_FILE* stream, const char* old_name, const char* new_name);
 
 #ifdef __cplusplus
 }

--- a/protected_fs_c/sgx_tprotected_fs/CMakeLists.txt
+++ b/protected_fs_c/sgx_tprotected_fs/CMakeLists.txt
@@ -2,6 +2,8 @@
 include_directories("${PROJECT_SOURCE_DIR}")
 
 if (NOT NON_SGX_PROTECTED_FS)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SGX_COMMON_CFLAGS} -nostdinc -fvisibility=hidden -fPIC -fstack-protector")
+
 include_directories("${SGX_SDK}/include")
 include_directories("${SGX_SDK}/include/tlibc")
 include_directories("${SGX_SDK}/include/libcxx")

--- a/protected_fs_c/sgx_tprotected_fs/Readme.md
+++ b/protected_fs_c/sgx_tprotected_fs/Readme.md
@@ -1,3 +1,0 @@
-# Note
-
-Please visit our [homepage](https://github.com/baidu/rust-sgx-sdk) for usage. Thanks!

--- a/protected_fs_c/sgx_tprotected_fs/file_crypto.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/file_crypto.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "protected_fs_file.h"
 #ifdef NON_SGX_PROTECTED_FS

--- a/protected_fs_c/sgx_tprotected_fs/file_flush.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/file_flush.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "protected_fs_config.h"
 

--- a/protected_fs_c/sgx_tprotected_fs/file_init.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/file_init.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "protected_fs_config.h"
 

--- a/protected_fs_c/sgx_tprotected_fs/file_read_write.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/file_read_write.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "protected_fs_config.h"
 

--- a/protected_fs_c/sgx_tprotected_fs/file_version.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/file_version.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "se_version.h"
 

--- a/protected_fs_c/sgx_tprotected_fs/lru_cache.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/lru_cache.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "lru_cache.h"
 

--- a/protected_fs_c/sgx_tprotected_fs/lru_cache.h
+++ b/protected_fs_c/sgx_tprotected_fs/lru_cache.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #pragma once
 

--- a/protected_fs_c/sgx_tprotected_fs/non_sgx_protected_fs.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/non_sgx_protected_fs.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "protected_fs_config.h"
 

--- a/protected_fs_c/sgx_tprotected_fs/protected_fs_file.h
+++ b/protected_fs_c/sgx_tprotected_fs/protected_fs_file.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #pragma once
 
@@ -229,6 +232,7 @@ public:
 
 	// Add for MesaTEE
 	int32_t get_current_meta_gmac(sgx_aes_gcm_128bit_tag_t out_gmac);
+	int32_t rename_meta(const char* old_name, const char* new_name);
 };
 
 #pragma pack(pop)

--- a/protected_fs_c/sgx_tprotected_fs/protected_fs_nodes.h
+++ b/protected_fs_c/sgx_tprotected_fs/protected_fs_nodes.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #pragma once
 
@@ -71,7 +74,7 @@ typedef struct _meta_data_encrypted
 	int64_t       size;
 	
 	sgx_mc_uuid_t mc_uuid; // not used
-	uint32_t      mc_value; // not usee
+	uint32_t      mc_value; // not used
 
 	sgx_aes_gcm_128bit_key_t mht_key;
 	sgx_aes_gcm_128bit_tag_t mht_gmac;

--- a/protected_fs_c/sgx_tprotected_fs/se_version.h
+++ b/protected_fs_c/sgx_tprotected_fs/se_version.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 #define STRFILEVER    "2.6.100.51363"
 #define COPYRIGHT      "Copyright (C) 2019 Intel Corporation"
 

--- a/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs.cpp
+++ b/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "sgx_tprotected_fs.h"
 #include "sgx_tprotected_fs_t.h"
@@ -238,8 +241,20 @@ int32_t sgx_fclear_cache(SGX_FILE* stream)
 int32_t sgx_get_current_meta_gmac(SGX_FILE* stream, sgx_aes_gcm_128bit_tag_t out_gmac)
 {
 	if (stream == NULL)
-		return 1;
+		return -1;
+
 	protected_fs_file* file = (protected_fs_file*)stream;
+
 	return file->get_current_meta_gmac(out_gmac);
+}
+
+int32_t sgx_rename_meta(SGX_FILE* stream, const char* old_name, const char* new_name)
+{
+	if (stream == NULL)
+		return -1;
+
+	protected_fs_file* file = (protected_fs_file*)stream;
+
+	return file->rename_meta(old_name, new_name);
 }
 

--- a/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs_t.h
+++ b/protected_fs_c/sgx_tprotected_fs/sgx_tprotected_fs_t.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef SGX_TPROTECTED_FS_T_H__
 #define SGX_TPROTECTED_FS_T_H__

--- a/protected_fs_c/sgx_tprotected_fs/tprotected_fs.h
+++ b/protected_fs_c/sgx_tprotected_fs/tprotected_fs.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef _TPROTECTED_FS_H_
 #define _TPROTECTED_FS_H_

--- a/protected_fs_c/sgx_uprotected_fs/CMakeLists.txt
+++ b/protected_fs_c/sgx_uprotected_fs/CMakeLists.txt
@@ -1,8 +1,7 @@
-
 if (NOT NON_SGX_PROTECTED_FS)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SGX_COMMON_CFLAGS} -fPIC -Wno-attributes")
 include_directories("${SGX_SDK}/include")
 endif()
-
 
 add_library(uprotected_fs STATIC 
     sgx_uprotected_fs.cpp 

--- a/protected_fs_c/sgx_uprotected_fs/sgx_uprotected_fs.cpp
+++ b/protected_fs_c/sgx_uprotected_fs/sgx_uprotected_fs.cpp
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include "protected_fs_config.h"
 

--- a/protected_fs_c/sgx_uprotected_fs/uprotected_fs.h
+++ b/protected_fs_c/sgx_uprotected_fs/uprotected_fs.h
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #ifndef _UPROTECTED_FS_H_
 #define _UPROTECTED_FS_H_

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 #![allow(non_camel_case_types)]
 
 use cfg_if::cfg_if;

--- a/src/sgx_fs_inner.rs
+++ b/src/sgx_fs_inner.rs
@@ -1,16 +1,19 @@
-// Copyright 2019 MesaTEE Authors
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #[cfg(feature = "mesalock_sgx")]
 use std::prelude::v1::*;
@@ -163,6 +166,12 @@ impl SgxFile {
         self.0
             .get_current_meta_gmac(meta_gmac)
             .map_err(Error::from_raw_os_error)
+    }
+
+    pub fn rename_meta(&self, old_name: &Path, new_name: &Path) -> io::Result<()> {
+        let old = cstr(old_name)?;
+        let new = cstr(new_name)?;
+        self.0.rename_meta(&old, &new).map_err(Error::from_raw_os_error)
     }
 }
 


### PR DESCRIPTION
## Refactor for MesaTEE
- Remove cmake build dependency
- Change licence
- Support rename_meta for ProtectedFile
- Support read_at for ProtectedFile
## CI Passed
https://ci.mesalock-linux.org/mesalock-linux/protected_fs_rs/71
